### PR TITLE
Resolve memory leaks and a build error

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -902,16 +902,24 @@ _evhtp_request_parser_header_key(htparser * p, const char * data, size_t len) {
     char               * key_s;     /* = strndup(data, len); */
     evhtp_header_t     * hdr;
 
-    key_s      = malloc(len + 1);
+    key_s = malloc(len + 1);
+    if (key_s == NULL) {
+      return -1;
+    }
+
     key_s[len] = '\0';
     memcpy(key_s, data, len);
 
     if ((hdr = evhtp_header_key_add(c->request->headers_in, key_s, 0)) == NULL) {
         c->request->status = EVHTP_RES_FATAL;
+        free(key_s);
         return -1;
     }
 
     hdr->k_heaped = 1;
+
+    free(key_s);
+
     return 0;
 }
 

--- a/test_proxy.c
+++ b/test_proxy.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <signal.h>
 #include <errno.h>
 #include <evhtp.h>
 


### PR DESCRIPTION
This patches resolves two memory leaks that occur when a call in _evhtp_request_parser_header_key fails as well as when the function returns. The second patch resolves a build error caused by the missing declaration of SIGTERM. For a more detailed description please refer to the single commit messages.
