### PR TITLE
install onigposix.h to /usr/local/include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,8 @@ endif()
 install (FILES evhtp.h DESTINATION include)
 install (FILES htparse/htparse.h DESTINATION include)
 install (FILES evthr/evthr.h DESTINATION include)
-
+install (FILES oniguruma/onigposix.h DESTINATION include)
+ 
 IF (WIN32)
    install (FILES compat/sys/queue.h DESTINATION include/sys)
    install (FILES oniguruma/onigposix.h DESTINATION include)


### PR DESCRIPTION
https://github.com/haiwen/seafile/issues/1158

   building seafile-server fails because `onigposix.h` is not installed into `/usr/local/include`:

```
   In file included from http-server.c:15:0:
   /usr/local/include/evhtp.h:11:23: fatal error: onigposix.h: No such file or directory
   compilation terminated.
   Makefile:697: recipe for target 'http-server.o' failed
   make[3]: *** [http-server.o] Error 1
   make[3]: *** Waiting for unfinished jobs....
   mv -f .deps/repo-op.Tpo .deps/repo-op.Po
   make[3]: Leaving directory '/tmp/seafile-server-build/seafile-5.0.0/server'
   Makefile:1248: recipe for target 'all-recursive' failed
   make[2]: *** [all-recursive] Error 1
   make[2]: Leaving directory '/tmp/seafile-server-build/seafile-5.0.0/server'
   Makefile:467: recipe for target 'all-recursive' failed
   make[1]: *** [all-recursive] Error 1
   make[1]: Leaving directory '/tmp/seafile-server-build/seafile-5.0.0'
   Makefile:399: recipe for target 'all' failed
   make: *** [all] Error 2
   [ERROR] error when running command:
           make -j2

   [INFO] remove builddir before exit
   ./build-server.py --version=5.0.2 --libsearpc_version=3.0.7       517.25s user 50.90s system 152% cpu 6:12.60 total
```

```
root@locky ..afile/env_seafile/library_dev/libevhtp (git)-[master] # make install
Build Type: Release
Std CFLAGS:  -Wall -fno-strict-aliasing -DPROJECT_VERSION="1.2.0" -D_BSD_SOURCE -D_POSIX_C_SOURCE=200112
Dbg CFLAGS: -g -Wall -fno-strict-aliasing -ggdb
Rel CFLAGS: -O3 -DNDEBUG -Wall -fno-strict-aliasing
CMake Warning (dev) at CMakeLists.txt:214 (add_executable):
  Policy CMP0037 is not set: Target names should not be reserved and should
  match a validity pattern.  Run "cmake --help-policy CMP0037" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  The target name "test" is reserved or not valid for certain CMake features,
  such as generator expressions, and may result in undefined behavior.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done
-- Generating done
-- Build files have been written to: /opt/seafile/env_seafile/library_dev/libevhtp
[ 82%] Built target libevhtpShared
[ 85%] Built target test
[ 89%] Built target test_basic
[ 92%] Built target test_client
[ 96%] Built target test_proxy
[100%] Built target test_vhost
Install the project...
-- Install configuration: "Release"
-- Up-to-date: /usr/local/lib/libevhtp.so
-- Up-to-date: /usr/local/include/evhtp.h
-- Up-to-date: /usr/local/include/htparse.h
-- Up-to-date: /usr/local/include/evthr.h
-- Installing: /usr/local/include/onigposix.h       # <------------ properly installed
```
